### PR TITLE
fix: 升级 vite 到 7.3.2 修复 CVE-2026-39363 任意文件读取漏洞

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "globals": "^17.9.0",
     "typescript": "^5.2.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^7.3.1"
+    "vite": "^7.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3068,10 +3068,10 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
-vite@^7.3.1:
-  version "7.3.1"
-  resolved "https://repo.huaweicloud.com/repository/npm/vite/-/vite-7.3.1.tgz#7f6cfe8fb9074138605e822a75d9d30b814d6507"
-  integrity sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==
+vite@^7.3.2:
+  version "7.3.2"
+  resolved "https://repo.huaweicloud.com/repository/npm/vite/-/vite-7.3.2.tgz#cb041794d4c1395e28baea98198fd6e8f4b96b5c"
+  integrity sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==
   dependencies:
     esbuild "^0.27.0"
     fdir "^6.5.0"


### PR DESCRIPTION
## 修复内容

修复 **Dependabot Alert #18**（[安全告警链接](https://github.com/xiaomizhoubaobei/prompt_generator/security/dependabot/18)）所涉及的高危漏洞。

### 漏洞信息

- **CVE**：CVE-2026-39363（GHSA-p9ff-h696-f583）
- **漏洞等级**：高危（High，CVSS v4 评分 8.2）
- **受影响包**：`vite`（npm 开发依赖）
- **漏洞描述**：Vite Dev Server 的 WebSocket `fetchModule` 方法未执行 `server.fs` 访问控制检查，攻击者可利用 `vite:invoke` 事件配合 `file://` 协议与 `?raw`/`?inline` 参数读取服务器上的任意文件（任意文件读取漏洞）
- **受影响版本**：`>= 7.0.0, <= 7.3.1`
- **修复版本**：`7.3.2`

### 变更内容

- `package.json`：将 `vite` 从 `^7.3.1` 升级为 `^7.3.2`
- `yarn.lock`：同步更新 vite 锁文件条目至 `7.3.2`

### 验证

- ✅ pre-commit 全量检查通过（gitleaks 密钥扫描、trailing-whitespace、end-of-file-fixer、check-yaml、check-added-large-files、check-toml）
- ✅ GPG 签名提交

### GPG 签名信息

- **密钥ID**：`97CD918AF3513964`
- **密钥身份**：`qixiaoxin@stu.sqxy.edu.cn`
- **签名方式**：GPG 签名提交

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Vite development tooling to version 7.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->