### PR TITLE
feat(config): 新增 .watchflow 安全规则配置，移除强制推送规则

### DIFF
--- a/.watchflow/rules.yaml
+++ b/.watchflow/rules.yaml
@@ -1,0 +1,25 @@
+rules:
+  - description: "禁止在代码变更中硬编码密钥或敏感信息"
+    enabled: true
+    severity: critical
+    event_types: [ "pull_request" ]
+    parameters:
+      security_patterns: [ "api_key", "secret", "password", "token", "private_key", "access_key", "auth_token" ]
+  - description: "所有提交必须使用 GPG/SSH/S-MIME 签名"
+    enabled: true
+    severity: critical
+    event_types: [ "pull_request" ]
+    parameters:
+      require_signed_commits: true
+  - description: "禁止直接合并到受保护分支，必须通过 PR 流程"
+    enabled: true
+    severity: critical
+    event_types: [ "pull_request" ]
+    parameters:
+      protected_branches: [ "main", "master" ]
+  - description: "PR 标题必须符合 Conventional Commits 规范"
+    enabled: true
+    severity: high
+    event_types: [ "pull_request" ]
+    parameters:
+      title_pattern: "^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\\(.+\\))?!?: .+"

--- a/.watchflow/rules.yaml
+++ b/.watchflow/rules.yaml
@@ -11,10 +11,10 @@ rules:
     event_types: [ "pull_request" ]
     parameters:
       require_signed_commits: true
-  - description: "禁止直接合并到受保护分支，必须通过 PR 流程"
+  - description: "禁止绕过 PR 直接推送到受保护分支，必须通过 PR 流程变更"
     enabled: true
     severity: critical
-    event_types: [ "pull_request" ]
+    event_types: [ "push" ]
     parameters:
       protected_branches: [ "main", "master" ]
   - description: "PR 标题必须符合 Conventional Commits 规范"


### PR DESCRIPTION
根据 Kimi 对话要求，新增 .watchflow/rules.yaml 安全规则配置，包含 4 条安全规则：
- 禁止在代码变更中硬编码密钥或敏感信息
- 所有提交必须使用 GPG/SSH/S-MIME 签名
- 禁止绕过 PR 直接推送到受保护分支，必须通过 PR 流程变更
- PR 标题必须符合 Conventional Commits 规范

已按要求移除 no_force_push（禁止强制推送）规则。

**修复（Qodo 代码审查）**：原「受保护分支」规则使用 `event_types: ["pull_request"]` + `protected_branches`，会在 PR 事件上拒绝指向 main/master 的合法 PR，与规则自身要求（受保护分支必须通过 PR 变更）相矛盾。已将 `event_types` 修正为 `["push"]`，使规则在绕过 PR 的直推事件上触发，真正拦截直接推送到受保护分支的操作。