### PR TITLE
fix(codeql): 修复 CodeQL 构建失败并统一 action 版本到 v4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,10 +40,13 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
-    - name: 自动构建
-      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+    - name: 安装依赖并构建（自定义构建，CodeQL autobuild 无法自动识别 pnpm 项目）
+      run: |
+        npm install -g pnpm
+        pnpm install
+        pnpm build
 
     - name: 执行 CodeQL 分析
-      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## 修复 CodeQL 构建失败与 action 版本不一致

### 问题
1. **CodeQL autobuild 构建失败**：CodeQL 无法自动构建此 pnpm + vite 的 TypeScript 项目，报错 "我们无法自动构建您的代码"。
2. **CodeQL action 版本不一致**：`init` 已升级到 v4.37.7，但 `autobuild` 和 `analyze` 仍为 v4.37.6，导致报错 "加载了版本 4.37.7 的配置文件，但运行的是版本 4.37.6"。

### 修复内容
- 用自定义构建步骤（pnpm install + pnpm build）替换 autobuild，解决自动构建失败的问题。
- 将 analyze action 从 v4.37.6 升级到 v4.37.7，与 init 保持一致，消除版本不一致报错。

关联 ISSUE #1