### PR TITLE
chore(cnb): CodeQL 工作流改用 corepack 尊重 pnpm 置顶版本并启用 --frozen-lockfile

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,8 +42,11 @@ jobs:
 
     - name: 安装依赖并构建（自定义构建，CodeQL autobuild 无法自动识别 pnpm 项目）
       run: |
-        npm install -g pnpm
-        pnpm install
+        # 使用 corepack 尊重 package.json 中置顶的 pnpm 版本，避免误装 NPM 最新版导致锁文件不匹配
+        corepack enable
+        corepack prepare pnpm@11.21.0 --activate
+        # 使用 --frozen-lockfile，若锁文件与 package.json 不同步则快速失败而非悄然变更
+        pnpm install --frozen-lockfile
         pnpm build
 
     - name: 执行 CodeQL 分析


### PR DESCRIPTION
## 修改说明

根据 CodeQL bot 的提示，原工作流使用 `npm install -g pnpm` 会安装 NPM 注册表上的最新版 pnpm，忽略项目在 `package.json` 中置顶的版本（`packageManager: pnpm@11.21.0`），可能导致失败或锁文件不匹配。

改为使用 corepack 尊重置顶版本，并启用 `--frozen-lockfile` 快速失败。

## 额外效果
- `corepack prepare pnpm@11.21.0 --activate` 尊重置顶版本，避免误装最新版。
- `pnpm install --frozen-lockfile`：若锁文件与 `package.json` 不同步，CI 会快速失败，而非悄然变更锁文件。