### PR TITLE
feat(cicd): docker 工作流固定 Node.js 20 版本

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,13 @@ jobs:
             - name: 检出代码
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+            # 固定 Node 20：runner 默认 Node 版本不受控（Node 25+ 起 corepack 不再随 Node 捆绑），
+            # 为保证后续 node -p / npm install -g pnpm 等步骤行为稳定，显式锁定版本。
+            - name: 安装 Node.js
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              with:
+                  node-version: 20
+
             - name: 从 package.json 提取版本号
               id: version
               run: |


### PR DESCRIPTION
## 背景

GitHub Actions 的 `docker.yml` 工作流中，runner 默认 Node.js 版本不受控（Node 25+ 起 corepack 不再随 Node 捆绑，且 pnpm 11 需要 Node ≥ 20）。为保证 `node -p` 提取版本、`npm install -g pnpm` 等步骤行为稳定，按仓库 SHA 固定惯例显式锁定 Node 20。

## 变更

- 新增 `actions/setup-node` 步骤（SHA 固定至 v4.4.0），`node-version: 20`，置于提取版本号之前。

## 涉及文件

- `.github/workflows/docker.yml`
