### PR TITLE
fix(build): 将 manualChunks 改为包名精确匹配以修复分包逻辑

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,8 @@ export default defineConfig({
     rollupOptions: {
       output: {
         // rolldown-vite（vite 8）不再支持对象形式的 manualChunks，仅接受函数形式
-        // 这里改写为函数形式，从模块 id 中精确提取包名进行分包，保持与原对象配置一致的分包逻辑
+        // 这里改写为函数形式，从模块 id 中精确提取包名并按命名空间归集分包
+        // （相比原对象配置覆盖了同族包，并将 react-router-dom 纳入 react-vendor）
         manualChunks(id) {
           // 仅处理 node_modules 中的依赖模块，避免对业务源码误分包
           if (!id.includes('node_modules')) return undefined;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,24 +14,31 @@ export default defineConfig({
     rollupOptions: {
       output: {
         // rolldown-vite（vite 8）不再支持对象形式的 manualChunks，仅接受函数形式
-        // 这里改写为函数形式，依据模块 id 中的包名进行分包，保持与原对象配置一致的分包逻辑
+        // 这里改写为函数形式，从模块 id 中精确提取包名进行分包，保持与原对象配置一致的分包逻辑
         manualChunks(id) {
           // 仅处理 node_modules 中的依赖模块，避免对业务源码误分包
           if (!id.includes('node_modules')) return undefined;
+          // 从模块 id 中精确解析包名，避免对路径子串的误匹配
+          // 例：/path/node_modules/@radix-ui/react-dialog/... -> @radix-ui/react-dialog
+          //     /path/node_modules/react-dom/...                 -> react-dom
+          const after = id.split('node_modules/').pop()!;
+          const pkg = after.startsWith('@')
+            ? after.split('/').slice(0, 2).join('/')
+            : after.split('/')[0];
           // 将 React 核心库单独打包
-          if (id.includes('/react') || id.includes('react-dom') || id.includes('react-icons') || id.includes('react-router')) {
+          if (['react', 'react-dom', 'react-icons', 'react-router-dom'].includes(pkg)) {
             return 'react-vendor';
           }
-          // 将 Radix UI 组件库单独打包
-          if (id.includes('@radix-ui')) {
+          // 将 Radix UI 组件库单独打包（按命名空间精确匹配，避免 react 子路径误入 react-vendor）
+          if (pkg.startsWith('@radix-ui')) {
             return 'radix-ui';
           }
-          // 将 CodeMirror 编辑器核心单独打包
-          if (id.includes('@codemirror') || id.includes('codemirror')) {
+          // 将 CodeMirror 编辑器核心单独打包（精确匹配 @codemirror 命名空间，避免 @uiw/react-codemirror 等被误纳入）
+          if (pkg.startsWith('@codemirror') || pkg === 'codemirror') {
             return 'codemirror-core';
           }
           // 将其他大型依赖单独打包
-          if (id.includes('@reduxjs/toolkit') || id.includes('react-redux') || id.includes('class-variance-authority')) {
+          if (['@reduxjs/toolkit', 'react-redux', 'class-variance-authority'].includes(pkg)) {
             return 'vendor';
           }
           // 其余依赖不强制分包，交由默认逻辑处理


### PR DESCRIPTION
### 背景

PR #67 将 `vite.config.ts` 中 `manualChunks` 从对象形式改写为函数形式以兼容 rolldown-vite（vite 8），但评审（pullrequestreview-5026428386）指出函数形式采用**路径子串匹配**引入了两个分包逻辑 bug。

### 问题

1. `id.includes("/react")` 会误匹配 `@radix-ui/react-slot`、`@radix-ui/react-label` 等路径（含 `/react-slot`、`/react-label`），使 Radix UI 组件被错误分到 `react-vendor` 而非 `radix-ui`；同时 `react-redux`、`lucide-react`、`@uiw/react-codemirror` 等也受影响。
2. `id.includes("codemirror")` 会误捕获 `@uiw/react-codemirror`、`@uiw/codemirror-themes`（二者均在 `package.json`），将其错误分到 `codemirror-core`。

### 修复

改为从模块 id 中**精确解析包名**后按包名匹配：

- 从 `node_modules/` 之后提取包名（含 scoped 包 `@scope/pkg`）。
- `react-vendor`：精确匹配 `react` / `react-dom` / `react-icons` / `react-router-dom`。
- `radix-ui`：`pkg.startsWith("@radix-ui")`。
- `codemirror-core`：`pkg.startsWith("@codemirror")` 或 `pkg === "codemirror"`。
- `vendor`：`@reduxjs/toolkit` / `react-redux` / `class-variance-authority`。

### 验证

本地 `pnpm build` 通过，产物含预期的 `react-vendor` / `radix-ui` / `codemirror-core` / `vendor` 四组分包。
